### PR TITLE
Add "conan_recipe_root" parameter to workflow files

### DIFF
--- a/.github/workflows/conan-package-create-linux.yml
+++ b/.github/workflows/conan-package-create-linux.yml
@@ -17,6 +17,11 @@ on:
         default: ""
         type: string
 
+      conan_recipe_root:
+        required: false
+        default: "."
+        type: string
+
 permissions:
   contents: read
 
@@ -94,7 +99,7 @@ jobs:
             ${{ runner.os }}-conan-downloads-
 
       - name: Export the Package (binaries)
-        run: conan create . ${{ inputs.recipe_id_full }} --build=missing --update ${{ inputs.conan_extra_args }}
+        run: conan create ${{ inputs.conan_recipe_root }} ${{ inputs.recipe_id_full }} --build=missing --update ${{ inputs.conan_extra_args }}
 
       - name: Upload the Package(s)
         if: ${{ always() && !inputs.conan_internal }}

--- a/.github/workflows/conan-package-create-macos.yml
+++ b/.github/workflows/conan-package-create-macos.yml
@@ -17,6 +17,11 @@ on:
         default: ""
         type: string
 
+      conan_recipe_root:
+        required: false
+        default: "."
+        type: string
+
 permissions:
   contents: read
 
@@ -94,7 +99,7 @@ jobs:
             ${{ runner.os }}-conan-downloads-
 
       - name: Export the Package (binaries)
-        run: conan create . ${{ inputs.recipe_id_full }} --build=missing --update ${{ inputs.conan_extra_args }}
+        run: conan create ${{ inputs.conan_recipe_root }} ${{ inputs.recipe_id_full }} --build=missing --update ${{ inputs.conan_extra_args }}
 
       - name: Upload the Package(s)
         if: ${{ always() && !inputs.conan_internal }}

--- a/.github/workflows/conan-package-create-windows.yml
+++ b/.github/workflows/conan-package-create-windows.yml
@@ -17,6 +17,11 @@ on:
         default: ""
         type: string
 
+      conan_recipe_root:
+        required: false
+        default: "."
+        type: string
+
 permissions:
   contents: read
 
@@ -88,7 +93,7 @@ jobs:
             ${{ runner.os }}-conan-downloads-
 
       - name: Export the Package (binaries)
-        run: conan create . ${{ inputs.recipe_id_full }} --build=missing --update ${{ inputs.conan_extra_args }}
+        run: conan create ${{ inputs.conan_recipe_root }} ${{ inputs.recipe_id_full }} --build=missing --update ${{ inputs.conan_extra_args }}
 
       - name: Upload the Package(s)
         if: ${{ always() && !inputs.conan_internal }}

--- a/.github/workflows/conan-package-release.yml
+++ b/.github/workflows/conan-package-release.yml
@@ -77,6 +77,12 @@ on:
         default: ''
         type: string
 
+      conan_recipe_root:
+        required: false
+        default: "."
+        description: 'location of the conanfile.py defaults to `.`'
+        type: string
+
   workflow_call:
     inputs:
       organization:
@@ -199,7 +205,7 @@ jobs:
 
       - name: Export the Package
         if: ${{ inputs.repository != 'Cura' && inputs.repository!='Uranium' }}
-        run: conan export . ${{ steps.get-conan-broadcast-data.outputs.recipe_id_full }} ${{ inputs.conan_extra_args }}
+        run: conan export ${{ inputs.conan_recipe_root }} ${{ steps.get-conan-broadcast-data.outputs.recipe_id_full }} ${{ inputs.conan_extra_args }}
 
       - name: Install system requirements for building
         run: |

--- a/.github/workflows/conan-recipe-export.yml
+++ b/.github/workflows/conan-recipe-export.yml
@@ -21,6 +21,11 @@ on:
         default: ""
         type: string
 
+      conan_recipe_root:
+        required: false
+        default: "."
+        type: string
+
 permissions:
   contents: read
 
@@ -97,7 +102,7 @@ jobs:
             ${{ runner.os }}-conan-downloads-
 
       - name: Export the Package
-        run: conan export . ${{ inputs.recipe_id_full }} ${{ inputs.conan_extra_args }}
+        run: conan export ${{ inputs.conan_recipe_root }} ${{ inputs.recipe_id_full }} ${{ inputs.conan_extra_args }}
 
       - name: Create the latest alias
         if: always()


### PR DESCRIPTION
The commit introduces a new "conan_recipe_root" input parameter to all the conan package creation workflows. This parameter allows user to specify the location of the conan recipe. Default value set to the current directory '.'. This change affects package creation workflows for Windows, macOS and Linux as well as the recipe export workflow.

Contribute to NP-186