### PR TITLE
Use force in conan profile

### DIFF
--- a/.github/workflows/conan-package-release.yml
+++ b/.github/workflows/conan-package-release.yml
@@ -169,7 +169,7 @@ jobs:
           mkdir -p /home/runner/.conan/downloads
 
       - name: Create default Conan profile
-        run: conan profile new default --detect
+        run: conan profile new default --detect --force
 
       - name: Get Conan configuration
         run: |


### PR DESCRIPTION
selfhosted runner requires --force to create new conan profile as the machine starts at a state with an existing conan profile