### PR TITLE
Add explicit Python dependency to build libxcrypt

### DIFF
--- a/.github/workflows/requirements-runner.txt
+++ b/.github/workflows/requirements-runner.txt
@@ -1,3 +1,4 @@
 conan>=1.64.0,<2.0.0
 sip>=6.8.1
 sentry-cli==2.21.2
+passlib


### PR DESCRIPTION
The `passlib` module seems to be absent from the default Python install since we had to switch to MacOS 12. Adding it as an explicit dependency.