### PR TITLE
move up the msi upload step

### DIFF
--- a/.github/workflows/cura-installer-windows.yml
+++ b/.github/workflows/cura-installer-windows.yml
@@ -130,6 +130,15 @@ jobs:
           & signtool sign /v /fd sha256 /tr http://timestamp.sectigo.com /td sha256 /f C:\actions-runner\code_sign.cer /csp "eToken Base Cryptographic Provider" /kc ${{ secrets.WIN_TOKEN_CONTAINER }} "${{steps.filename.outputs.INSTALLER_FILENAME }}.msi"
         working-directory: dist
         timeout-minutes: 2
+        
+      - name: Upload the installer msi
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: ${{steps.filename.outputs.INSTALLER_FILENAME }}-msi
+          path: |
+            dist/${{steps.filename.outputs.INSTALLER_FILENAME }}.msi
+          retention-days: 5
 
       - name: Create the Windows exe installer (Powershell)
         if: ${{ always() }}
@@ -153,15 +162,6 @@ jobs:
 #      - name: Upload the Package(s)
 #        if: ${{ always() && ! inputs.conan_internal }}
 #        run: conan upload "*" -r cura --all -c
-
-      - name: Upload the installer msi
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4.3.3
-        with:
-          name: ${{steps.filename.outputs.INSTALLER_FILENAME }}-msi
-          path: |
-            dist/${{steps.filename.outputs.INSTALLER_FILENAME }}.msi
-          retention-days: 5
 
       - name: Upload the installer exe
         if: ${{ always() }}


### PR DESCRIPTION
Move the upload step higher in the build process as soon as the package is created and signed.