### PR TITLE
Update branch matching regex in upload_conan_recipes.py

### DIFF
--- a/runner_scripts/upload_conan_recipes.py
+++ b/runner_scripts/upload_conan_recipes.py
@@ -10,7 +10,7 @@ def upload_changed_recipes(args):
     configs = dict(zip([ str(f).split("/")[1] for f in files ], [ Path(*str(f).split("/")[:2]).joinpath("config.yml") for f in files ]))
 
     packages = []
-    channel = "stable" if "main" in args.branch else re.match(r"CURA-\d*", args.branch)[0].lower().replace("-", "_")
+    channel = "stable" if "main" in args.branch else re.match(r"(CURA-\d*|NP-\d*|PP-\d*)", args.branch)[0].lower().replace("-", "_")
 
     for name, config in configs.items():
         if not config.exists():


### PR DESCRIPTION
Extend the branch regex to also match NP- and PP-prefixed branches. This ensures that all relevant branches are correctly identified and processed for the appropriate channel during the upload of Conan recipes.

See: https://github.com/Ultimaker/conan-ultimaker-index/pull/14

Contribute to NP-346