### PR TITLE
Add timeout to the executable sign step

### DIFF
--- a/.github/workflows/cura-installer-windows.yml
+++ b/.github/workflows/cura-installer-windows.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           & signtool sign /v /fd sha256 /tr http://timestamp.sectigo.com /td sha256 /f C:\actions-runner\code_sign.cer /csp "eToken Base Cryptographic Provider" /kc ${{ secrets.WIN_TOKEN_CONTAINER }} "CuraEngine.exe"
           & signtool sign /v /fd sha256 /tr http://timestamp.sectigo.com /td sha256 /f C:\actions-runner\code_sign.cer /csp "eToken Base Cryptographic Provider" /kc ${{ secrets.WIN_TOKEN_CONTAINER }} "UltiMaker-Cura.exe"
+        timeout-minutes: 2
 
       - name: Output the name file name and extension
         id: filename


### PR DESCRIPTION
2 minutes of timeout for the sign executable step to prevent build process getting stuck