### PR TITLE
CURA-12261 Preserve system reference to pynavlib

### DIFF
--- a/.github/workflows/cura-installer-macos.yml
+++ b/.github/workflows/cura-installer-macos.yml
@@ -125,12 +125,6 @@ jobs:
           plutil -convert xml1 cura_inst/packaging/MacOS/cura.entitlements
           pyinstaller ./cura_inst/UltiMaker-Cura.spec
 
-      - name: Restore the pynavlib path
-        run: |
-          codesign --remove-signature "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
-          install_name_tool -change @rpath/3DconnexionNavlib /Library/Frameworks/3DconnexionNavlib.framework/3DconnexionNavlib "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
-          codesign -s "$CODESIGN_IDENTITY" "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
-
       - name: Create the Macos dmg (Bash)
         run: python ../cura_inst/packaging/MacOS/build_macos.py --source_path ../cura_inst --dist_path . --cura_conan_version "${{ steps.prepare-distribution.outputs.CURA_VERSION }}" --filename "${{ steps.prepare-distribution.outputs.INSTALLER_FILENAME }}" --build_dmg --build_pkg --app_name "${{ steps.prepare-distribution.outputs.CURA_APP_NAME }}"
         working-directory: dist

--- a/.github/workflows/cura-installer-macos.yml
+++ b/.github/workflows/cura-installer-macos.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Restore the pynavlib path
         run: |
           codesign --remove-signature "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
-          install_name_tool -change @rpath/3DconnexionNavLib /Library/Frameworks/3DconnexionNavLib.framework/3DconnexionNavLib "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
+          install_name_tool -change @rpath/3DconnexionNavlib /Library/Frameworks/3DconnexionNavlib.framework/3DconnexionNavlib "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
           codesign -s "$CODESIGN_IDENTITY" "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
 
       - name: Create the Macos dmg (Bash)

--- a/.github/workflows/cura-installer-macos.yml
+++ b/.github/workflows/cura-installer-macos.yml
@@ -125,6 +125,12 @@ jobs:
           plutil -convert xml1 cura_inst/packaging/MacOS/cura.entitlements
           pyinstaller ./cura_inst/UltiMaker-Cura.spec
 
+      - name: Restore the pynavlib path
+        run: |
+          codesign --remove-signature "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
+          install_name_tool -change @rpath/3DconnexionNavLib /Library/Frameworks/3DconnexionNavLib.framework/3DconnexionNavLib "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
+          codesign -s "$CODESIGN_IDENTITY" "dist/UltiMaker Cura.app/Contents/Frameworks/pynavlib/_pynavlib.cpython-312-darwin.so"
+
       - name: Create the Macos dmg (Bash)
         run: python ../cura_inst/packaging/MacOS/build_macos.py --source_path ../cura_inst --dist_path . --cura_conan_version "${{ steps.prepare-distribution.outputs.CURA_VERSION }}" --filename "${{ steps.prepare-distribution.outputs.INSTALLER_FILENAME }}" --build_dmg --build_pkg --app_name "${{ steps.prepare-distribution.outputs.CURA_APP_NAME }}"
         working-directory: dist


### PR DESCRIPTION
This adds an extra step when building on Mac to restore the reference to the exernal library required by pynavlib.

:warning: do not merge before 3Dconnexion branch is merged

CURA-12261