### PR TITLE
Add support for alias tagging during npm package publishing

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -43,9 +43,15 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@ultimaker'
 
-      - name: Publish to GitHub Packages
+      - name: Publish to GitHub Packages (with version)
+        run: npm publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to GitHub Packages (with alias)
+        if: ${{ github.ref_name == 'main' }}
         run: |
-          npm publish
+          npm publish --tag latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Updated the workflow to publish with a 'latest' tag when on the main branch. This ensures proper versioning and aliasing for packages published to GitHub Packages.

NP-732