### PR TITLE
Revert "[CURA-12675] Don't need this workaround anymore."

### DIFF
--- a/.github/workflows/cura-installer-windows.yml
+++ b/.github/workflows/cura-installer-windows.yml
@@ -113,6 +113,19 @@ jobs:
           & signtool sign /v /fd sha256 /tr http://timestamp.sectigo.com /td sha256 /f C:\actions-runner\code_sign.cer /csp "eToken Base Cryptographic Provider" /kc ${{ secrets.WIN_TOKEN_CONTAINER }} "UltiMaker-Cura.exe"
         timeout-minutes: 2
 
+      - name: Workaround (need exact version of msvc redistributables)
+        run: |
+          $MSDIR="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Redist/MSVC"
+          if ( (dir -Exclude "v*" $MSDIR).Count -ne 1 ) { throw "(!!!) MULTIPLE MSVC VERSIONS IN '$MSDIR' -- NEED EXACTLY 1 TO SELECT A REDISTRIBUTABLE (!!!)" }
+          $MSDIR_R=(dir -Exclude "v*" $MSDIR)[0].FullName
+          $MSDIR_DLLS=(dir $MSDIR_R/x64/Microsoft.VC*.CRT)[0].FullName
+          copy $MSDIR_DLLS/concrt140.dll dist/UltiMaker-Cura/.
+          copy $MSDIR_DLLS/msvcp140.dll dist/UltiMaker-Cura/.
+          copy $MSDIR_DLLS/msvcp140_1.dll dist/UltiMaker-Cura/.
+          copy $MSDIR_DLLS/msvcp140_2.dll dist/UltiMaker-Cura/.
+          copy $MSDIR_DLLS/vcruntime140.dll dist/UltiMaker-Cura/.
+          copy $MSDIR_DLLS/vcruntime140_1.dll dist/UltiMaker-Cura/.
+
       - name: Workaround (some libs linking against python3 instead of python312)
         run: |
           copy Cura-workflows/python_dll_workaround/* dist/UltiMaker-Cura/.


### PR DESCRIPTION
Reverts Ultimaker/cura-workflows#39

Workaround might be still needed to point to correct DLL if the system is not using DLL injection due to AV