### PR TITLE
Support package overrides in CI workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,6 +43,11 @@ on:
         default: "150%"
         type: string
 
+      package_overrides:
+        required: false
+        default: ""
+        type: string
+
 permissions:
   contents: write
   deployments: write
@@ -57,8 +62,16 @@ jobs:
         with:
           install_system_dependencies: true
 
+      - name: Set package overrides
+        id: set_overrides
+        if: inputs.package_overrides != ''
+        uses: ultimaker/cura-workflows/.github/actions/set-package-overrides@main
+        with:
+          package_overrides: ${{ inputs.package_overrides }}
+          profile: cura.jinja
+
       - name: Install dependencies and build
-        run: conan build . -s build_type=Release --build=missing --update -g VirtualRunEnv ${{ inputs.conan_extra_args }}
+        run: conan build . --profile "${{ steps.set_overrides.outputs.profile || 'cura.jinja' }}" -s build_type=Release --build=missing --update -g VirtualRunEnv ${{ inputs.conan_extra_args }}
 
       - name: Run benchmark
         id: run-test

--- a/.github/workflows/extract-ticket-and-find-packages.yml
+++ b/.github/workflows/extract-ticket-and-find-packages.yml
@@ -1,0 +1,38 @@
+name: Extract Ticket and Find Packages
+
+on:
+  workflow_call:
+    outputs:
+      package_overrides:
+        description: "Conan package overrides discovered for the ticket"
+        value: ${{ jobs.find-packages.outputs.package_overrides }}
+      ticket:
+        description: "Extracted Jira ticket number"
+        value: ${{ jobs.extract-ticket.outputs.ticket }}
+
+permissions:
+  contents: read
+
+jobs:
+  extract-ticket:
+    name: Extract Jira ticket from branch
+    runs-on: ubuntu-latest
+    if: github.ref_name != 'main'
+    outputs:
+      ticket: ${{ steps.extract.outputs.ticket }}
+    steps:
+      - name: Extract ticket number
+        id: extract
+        run: |
+          branch="${{ github.head_ref || github.ref_name }}"
+          ticket=$(echo "$branch" | grep -oP '^(CURA|PP|NP)-\d+' || echo "")
+          echo "ticket=$ticket" >> $GITHUB_OUTPUT
+
+  find-packages:
+    name: Find ticket-specific packages
+    needs: [extract-ticket]
+    if: always() && needs.extract-ticket.outputs.ticket != ''
+    uses: ultimaker/cura-workflows/.github/workflows/find-package-by-ticket.yml@main
+    with:
+      jira_ticket_number: ${{ needs.extract-ticket.outputs.ticket }}
+    secrets: inherit

--- a/.github/workflows/extract-ticket-and-find-packages.yml
+++ b/.github/workflows/extract-ticket-and-find-packages.yml
@@ -31,7 +31,7 @@ jobs:
   find-packages:
     name: Find ticket-specific packages
     needs: [extract-ticket]
-    if: always() && needs.extract-ticket.outputs.ticket != ''
+    if: needs.extract-ticket.outputs.ticket != ''
     uses: ultimaker/cura-workflows/.github/workflows/find-package-by-ticket.yml@main
     with:
       jira_ticket_number: ${{ needs.extract-ticket.outputs.ticket }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,6 +18,11 @@ on:
         default: ""
         type: string
 
+      package_overrides:
+        required: false
+        default: ""
+        type: string
+
       runs_on:
         required: false
         default: "ubuntu-latest"
@@ -38,8 +43,16 @@ jobs:
         with:
           install_system_dependencies: true
 
+      - name: Set package overrides
+        id: set_overrides
+        if: inputs.package_overrides != ''
+        uses: ultimaker/cura-workflows/.github/actions/set-package-overrides@main
+        with:
+          package_overrides: ${{ inputs.package_overrides }}
+          profile: cura.jinja
+
       - name: Install dependencies and build unit test
-        run: conan build . -s build_type=Release --build=missing --update -c tools.build:skip_test=False ${{ inputs.test_use_pytest && '-g VirtualPythonEnv -c user.generator.virtual_python_env:dev_tools=True' || '' }} ${{ inputs.conan_extra_args }}
+        run: conan build . --profile "${{ steps.set_overrides.outputs.profile || 'cura.jinja' }}" -s build_type=Release --build=missing --update -c tools.build:skip_test=False ${{ inputs.test_use_pytest && '-g VirtualPythonEnv -c user.generator.virtual_python_env:dev_tools=True' || '' }} ${{ inputs.conan_extra_args }}
 
       - name: Run ctest-based unit test
         if: ${{ inputs.test_use_ctest }}


### PR DESCRIPTION
Allow for ticket aware workflow runs to execute the benchmark and unit tests on the engine while using the connected resources from branches across different repositories. This makes the tests more reliable as they would not flag a false positive when cross repository changes with dependency are introduced.

CURA-13113