### PR TITLE
Cura 13207 get diff

### DIFF
--- a/.github/actions/get-diff/action.yml
+++ b/.github/actions/get-diff/action.yml
@@ -41,6 +41,7 @@ runs:
           ALL_FILES="${CHANGED}"
         fi
         if [ -n "${ALL_FILES}" ]; then
+          FILES_QUOTED=$(echo "${ALL_FILES}" | sed "s/\([^ ]*\)/'\1'/g")
           echo "files=${ALL_FILES}" >> "$GITHUB_OUTPUT"
-          echo "files_quoted=$(echo "${ALL_FILES}" | sed "s/\([^ ]*\)/'\1'/g")" >> "$GITHUB_OUTPUT"
+          echo "files_quoted=${FILES_QUOTED}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/get-diff/action.yml
+++ b/.github/actions/get-diff/action.yml
@@ -1,0 +1,46 @@
+name: Get changed files
+description: >-
+  Gets changed files matching specified patterns and exposes them as step
+  outputs for use by downstream steps.
+
+inputs:
+  files:
+    description: Newline-separated glob patterns to filter changed files.
+    required: true
+  include_deleted:
+    description: Whether to include deleted files in the output.
+    required: false
+    default: 'false'
+
+outputs:
+  files:
+    description: Space-separated list of changed files.
+    value: ${{ steps.export.outputs.files }}
+  files_quoted:
+    description: Space-separated list of changed files, each wrapped in single quotes.
+    value: ${{ steps.export.outputs.files_quoted }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v46
+      with:
+        files: ${{ inputs.files }}
+
+    - name: Export diff outputs
+      id: export
+      shell: bash
+      run: |
+        CHANGED="${{ steps.changed-files.outputs.all_changed_files }}"
+        if [[ "${{ inputs.include_deleted }}" == "true" ]]; then
+          DELETED="${{ steps.changed-files.outputs.deleted_files }}"
+          ALL_FILES="${CHANGED}${CHANGED:+ }${DELETED}"
+        else
+          ALL_FILES="${CHANGED}"
+        fi
+        if [ -n "${ALL_FILES}" ]; then
+          echo "files=${ALL_FILES}" >> "$GITHUB_OUTPUT"
+          echo "files_quoted=$(echo "${ALL_FILES}" | sed "s/\([^ ]*\)/'\1'/g")" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/get-diff/action.yml
+++ b/.github/actions/get-diff/action.yml
@@ -41,7 +41,7 @@ runs:
           ALL_FILES="${CHANGED}"
         fi
         if [ -n "${ALL_FILES}" ]; then
-          FILES_QUOTED=$(echo "${ALL_FILES}" | sed "s/\([^ ]*\)/'\1'/g")
+          FILES_QUOTED=$(echo "${ALL_FILES}" | sed "s/\([^ ]\+\)/'\1'/g")
           echo "files=${ALL_FILES}" >> "$GITHUB_OUTPUT"
           echo "files_quoted=${FILES_QUOTED}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/lint-formatter.yml
+++ b/.github/workflows/lint-formatter.yml
@@ -22,22 +22,18 @@ jobs:
       - name: Setup the build environment
         uses: ultimaker/cura-workflows/.github/actions/setup-build-environment@main
 
-      - uses: greguintow/get-diff-action@v7
+      - id: get-diff
+        uses: ultimaker/cura-workflows/.github/actions/get-diff@main
         with:
-          PATTERNS: ${{ inputs.file_patterns }}
+          files: ${{ inputs.file_patterns }}
 
       - name: Format files
-        if: env.GIT_DIFF && !env.MATCHED_FILES
-        run: ${{ inputs.command }} ${{ env.GIT_DIFF_FILTERED }}
-
-      - name: Convert files list
-        id: convert-files-list
-        if: env.GIT_DIFF && !env.MATCHED_FILES
-        run: echo "files_list=${{ env.GIT_DIFF_FILTERED }}" | sed "s/'//g" >> $GITHUB_OUTPUT
+        if: steps.get-diff.outputs.files != ''
+        run: ${{ inputs.command }} ${{ steps.get-diff.outputs.files_quoted }}
 
       - uses: stefanzweifel/git-auto-commit-action@v7
-        if: env.GIT_DIFF && !env.MATCHED_FILES
+        if: steps.get-diff.outputs.files != ''
         with:
           commit_message: ${{ inputs.commit_message }}
-          file_pattern: ${{ steps.convert-files-list.outputs.files_list }}
+          file_pattern: ${{ steps.get-diff.outputs.files }}
 

--- a/.github/workflows/lint-tidier.yml
+++ b/.github/workflows/lint-tidier.yml
@@ -51,7 +51,7 @@ jobs:
           path: linter-result/
 
       - name: Run clang-tidy-pr-comments action
-        uses: platisd/clang-tidy-pr-comments@1.8.0
+        uses: platisd/clang-tidy-pr-comments@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           clang_tidy_fixes: linter-result/fixes.yml

--- a/.github/workflows/lint-tidier.yml
+++ b/.github/workflows/lint-tidier.yml
@@ -14,9 +14,10 @@ jobs:
         with:
           install_system_dependencies: true
 
-      - uses: greguintow/get-diff-action@v7
+      - id: get-diff
+        uses: ultimaker/cura-workflows/.github/actions/get-diff@main
         with:
-          PATTERNS: |
+          files: |
             include/**/*.h*
             src/**/*.c*
 
@@ -33,10 +34,10 @@ jobs:
         run: mkdir linter-result
 
       - name: Diagnose file(s)
-        if: env.GIT_DIFF && !env.MATCHED_FILES
+        if: steps.get-diff.outputs.files != ''
         continue-on-error: true
         run: |
-          clang-tidy -p ./build/Release/ --config-file=.clang-tidy ${{ env.GIT_DIFF_FILTERED }} --export-fixes=linter-result/fixes.yml
+          clang-tidy -p ./build/Release/ --config-file=.clang-tidy ${{ steps.get-diff.outputs.files_quoted }} --export-fixes=linter-result/fixes.yml
 
       - name: Save PR metadata
         run: |


### PR DESCRIPTION
This pull request introduces a new Action (`get-diff`) for detecting changed files in workflows. It updates the linting workflows to use this new action, improving consistency and maintainability. The main changes include adding the new action, updating workflow steps to use its outputs, and making minor improvements to workflow logic. It utilizes a public action and formats the output for consumption.

**Introduction of custom get-diff action:**

* Added `.github/actions/get-diff/action.yml`, a composite action that detects changed files based on glob patterns, supports inclusion of deleted files, and exposes outputs for downstream workflow steps.

- Workflow updates to use new action

* Improvements to workflow logic and output handling

**bugfix**

* Updated the version reference for `platisd/clang-tidy-pr-comments` in the `lint-tidier` (missing v)


CURA-13207